### PR TITLE
Fix build on macOS (& gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ out/
 cmake-build-debug
 cmake-build-release
 /data
-ext/SDL2/*/
+/ext/SDL2/**
 *~
 *.swp
 .vscode

--- a/cmake/FindSDL2_mixer.cmake
+++ b/cmake/FindSDL2_mixer.cmake
@@ -72,7 +72,7 @@ if(NOT SDL2_MIXER_INCLUDE_DIR AND SDL2MIXER_INCLUDE_DIR)
 entry initialized from old variable name")
 endif()
 
-if(APPLE)
+if(NOT SDL2_MIXER_INCLUDE_DIR AND APPLE)
   # Try to find the include in the SDL2_mixer framework bundle
   # This fixes CMake finding the header from SDL_mixer 1.2 when both 1.2 and 2.0 are installed
   find_path(SDL2_MIXER_INCLUDE_DIR SDL2_mixer/SDL_mixer.h
@@ -82,7 +82,9 @@ if(APPLE)
     PATH_SUFFIXES include include/SDL2
     PATHS ${SDL2_SEARCH_PATHS}
   )
-  set(SDL2_MIXER_INCLUDE_DIR "${SDL2_MIXER_INCLUDE_DIR}/Headers")
+  if (SDL2_MIXER_INCLUDE_DIR)
+    set(SDL2_MIXER_INCLUDE_DIR "${SDL2_MIXER_INCLUDE_DIR}/Headers")
+  endif()
 endif()
 
 if(NOT APPLE OR NOT EXISTS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h")

--- a/src/building/granary.c
+++ b/src/building/granary.c
@@ -1,4 +1,3 @@
-#include <ntdef.h>
 #include <cmath>
 #include "granary.h"
 


### PR DESCRIPTION
This fixes some CMake + code issues I ran across when trying to build the project on macOS for the first time:

**In CMake**
1. When not using a framework location it would append `/Headers` to the -NOTFOUND path in the variable, making it "valid" and not continue the search. Needless to say the resulting include path didn't work, and SDL_mixer.h wasn't found at build time.
2. It would append `/Headers` to the found path on the 2nd cmake run (after already finding a valid path on the first run). It should instead only attempt to look in the frameworks if no valid path was found yet.

**In granary.c**
The `ntdef.h` include isn't present on non-Windows platforms, and appears to be entirely unneeded. Note that I couldn't test whether it actually still builds on Windows, though.

**Other**
Also sneaking in a gitignore fix. I placed my SDL installation in ext/SDL2, but they didn't get ignored because the wildcard was broken.