### PR TITLE
Fix clang warnings

### DIFF
--- a/src/building/construction.c
+++ b/src/building/construction.c
@@ -956,8 +956,8 @@ int building_construction_place_building(int type, int x, int y) {
             city_warning_show(WARNING_DOCK_OPEN_WATER_NEEDED);
             return 0;
         }
-    } else if (GAME_ENV == ENGINE_ENV_PHARAOH && type == BUILDING_BOOTH ||
-        type == BUILDING_BANDSTAND || type == BUILDING_PAVILLION || type == BUILDING_FESTIVAL_SQUARE) {
+    } else if (GAME_ENV == ENGINE_ENV_PHARAOH && (type == BUILDING_BOOTH ||
+        type == BUILDING_BANDSTAND || type == BUILDING_PAVILLION || type == BUILDING_FESTIVAL_SQUARE)) {
         int booth_warning = 0;
         if (type == BUILDING_BOOTH)
             booth_warning = map_orientation_for_venue(x, y, 0, &building_orientation);
@@ -1504,8 +1504,8 @@ void building_construction_update(int x, int y, int grid_offset) {// update ghos
     } else if (data.required_terrain.meadow || data.required_terrain.rock || data.required_terrain.tree ||
                data.required_terrain.water || data.required_terrain.wall || data.required_terrain.groundwater) {
         // never mark as constructing
-    } else if (GAME_ENV == ENGINE_ENV_PHARAOH && type == BUILDING_BOOTH || type == BUILDING_BANDSTAND
-        || type == BUILDING_PAVILLION || type == BUILDING_FESTIVAL_SQUARE) {
+    } else if (GAME_ENV == ENGINE_ENV_PHARAOH && (type == BUILDING_BOOTH || type == BUILDING_BANDSTAND
+        || type == BUILDING_PAVILLION || type == BUILDING_FESTIVAL_SQUARE)) {
         // never mark as constructing; todo?
     } else {
         if (!(type == BUILDING_SENATE_UPGRADED && city_buildings_has_senate()) &&
@@ -1653,7 +1653,7 @@ void building_construction_place(void) { // confirm final placement
     }
     placement_cost *= length;
 
-    if (GAME_ENV == ENGINE_ENV_C3 && building_is_large_temple(type) || type == BUILDING_ORACLE) {
+    if (GAME_ENV == ENGINE_ENV_C3 && (building_is_large_temple(type) || type == BUILDING_ORACLE)) {
         building_warehouses_remove_resource(RESOURCE_MARBLE_C3, 2);
     }
     if (data.type == BUILDING_MENU_SMALL_TEMPLES) {

--- a/src/building/construction_clear.c
+++ b/src/building/construction_clear.c
@@ -69,9 +69,9 @@ static int clear_land_confirmed(int measure_only, int x_start, int y_start, int 
                 } else if (map_terrain_is(grid_offset, TERRAIN_WATER)) { // keep the "bridge is free" bug from C3
                     continue;
                 } else if (map_terrain_is(grid_offset, TERRAIN_AQUEDUCT) ||
-                           map_terrain_is(grid_offset, TERRAIN_NOT_CLEAR) &&
+                           (map_terrain_is(grid_offset, TERRAIN_NOT_CLEAR) &&
                            !map_terrain_is(grid_offset, TERRAIN_NOT_REMOVABLE) &&
-                           !map_terrain_exists_tile_in_radius_with_type(x, y, 1, 1, TERRAIN_FLOODPLAIN))
+                           !map_terrain_exists_tile_in_radius_with_type(x, y, 1, 1, TERRAIN_FLOODPLAIN)))
                     items_placed++;
                 continue;
             }

--- a/src/building/figure.c
+++ b/src/building/figure.c
@@ -831,13 +831,13 @@ static void spawn_figure_magistrate(building *b) {
 static void spawn_figure_temple(building *b) {
     check_labor_problem(b);
     if (has_figure_of_type(b, FIGURE_PRIEST) ||
-        building_is_large_temple(b->type) && b->prev_part_building_id) {
+        (building_is_large_temple(b->type) && b->prev_part_building_id)) {
         return;
     }
 
     map_point road;
-    if (building_is_temple(b->type) && map_has_road_access(b->x, b->y, b->size, &road) ||
-        building_is_large_temple(b->type) && map_has_road_access_temple_complex(b->x, b->y, &road)) {
+    if ((building_is_temple(b->type) && map_has_road_access(b->x, b->y, b->size, &road)) ||
+        (building_is_large_temple(b->type) && map_has_road_access_temple_complex(b->x, b->y, &road))) {
 
         spawn_labor_seeker(b, road.x, road.y, 50);
         int pct_workers = worker_percentage(b);

--- a/src/city/floods.c
+++ b/src/city/floods.c
@@ -170,8 +170,8 @@ void floodplains_tick_update() {
         map_update_floodplain_inundation(-1, (30 - data.flood_progress) * 25 - cycle_tick);
 
     // update grass growth
-    if (cycle_tick % 10 == 0 && cycle < cycle_flooding_start - 27 || cycle >= cycle_flooding_end - rest_period)
-    map_advance_floodplain_growth();
+    if (cycle_tick % 10 == 0 && (cycle < cycle_flooding_start - 27 || cycle >= cycle_flooding_end - rest_period))
+        map_advance_floodplain_growth();
 }
 
 void floodplains_save_state(buffer *floodplain_data) {

--- a/src/figure/action.c
+++ b/src/figure/action.c
@@ -341,7 +341,7 @@ void figure::action_perform() {
             case FIGURE_CART_PUSHER:
                 if (destination_building_id)
                     break;
-                if (!building_is_floodplain_farm(b) && b->state != BUILDING_STATE_VALID || b->figure_id != id)
+                if (!building_is_floodplain_farm(b) && (b->state != BUILDING_STATE_VALID || b->figure_id != id))
                     poof();
                 break;
             case FIGURE_WAREHOUSEMAN:

--- a/src/figuretype/crime.c
+++ b/src/figuretype/crime.c
@@ -125,12 +125,13 @@ void figure_generate_criminals(void) {
         int sentiment = city_sentiment();
         if (sentiment < 30) {
             if (random_byte() >= sentiment + 50) {
-                if (min_happiness <= 10)
+                if (min_happiness <= 10) {
                     if (GAME_ENV == ENGINE_ENV_C3) { // Temporary disable rioters in Egypt
                         generate_rioter(min_building);
                     } else if (GAME_ENV == ENGINE_ENV_PHARAOH) {
                         generate_mugger(min_building);
                     }
+                }
                 else if (min_happiness < 30)
                     generate_mugger(min_building);
                 else if (min_happiness < 50)

--- a/src/figuretype/missile.c
+++ b/src/figuretype/missile.c
@@ -76,8 +76,8 @@ void figure::missile_fire_at(int target_id, int missile_type) {
 
 bool figure::is_citizen() {
     if (action_state != FIGURE_ACTION_149_CORPSE) {
-        if (type && type != FIGURE_EXPLOSION && type != FIGURE_FORT_STANDARD &&
-            type != FIGURE_MAP_FLAG && type != FIGURE_FLOTSAM && type < FIGURE_INDIGENOUS_NATIVE ||
+        if ((type && type != FIGURE_EXPLOSION && type != FIGURE_FORT_STANDARD &&
+             type != FIGURE_MAP_FLAG && type != FIGURE_FLOTSAM && type < FIGURE_INDIGENOUS_NATIVE) ||
             type == FIGURE_TOWER_SENTRY) {
             return id;
         }

--- a/src/game/file_io.c
+++ b/src/game/file_io.c
@@ -880,8 +880,8 @@ void log_hex(file_piece *piece, int i, int offs) {
     for (int b = 0; b < s; b++) {
         char hexcode[3] = {0};
         uint8_t inbyte = piece->buf->get_value(b);
-        snprintf(hexcode, 4, "%02X", inbyte);
-        strncat(hexstr, hexcode, 4);
+        snprintf(hexcode, sizeof(hexcode)/sizeof(hexcode[0]), "%02X", inbyte);
+        strncat(hexstr, hexcode, sizeof(hexcode)/sizeof(hexcode[0]) - 1);
         if ((b + 1) % 4 == 0 || (b + 1) == s)
             strncat(hexstr, " ", 2);
     }

--- a/src/game/file_io.c
+++ b/src/game/file_io.c
@@ -885,7 +885,7 @@ void log_hex(file_piece *piece, int i, int offs) {
         if ((b + 1) % 4 == 0 || (b + 1) == s)
             strncat(hexstr, " ", 2);
     }
-    SDL_Log("Piece %s %03i/%i : %8i@ %-36s(%i) %s", piece->compressed ? "(C)" : "---", i + 1, savegame_data.num_pieces,
+    SDL_Log("Piece %s %03i/%i : %8i@ %-36s(%zu) %s", piece->compressed ? "(C)" : "---", i + 1, savegame_data.num_pieces,
             offs, hexstr, piece->buf->size(), fname);
 }
 static int read_compressed_chunk(FILE *fp, buffer *buf, int filepiece_size) {

--- a/src/map/tiles.c
+++ b/src/map/tiles.c
@@ -980,7 +980,7 @@ void map_tiles_set_water(int x, int y) { // todo: broken
 //    foreach_region_tile(x - 1, y - 1, x + 1, y + 1, set_water_image);
 }
 
-#define PH_FLOODPLAIN_GROWTH_MAX 6;
+#define PH_FLOODPLAIN_GROWTH_MAX 6
 int floodplain_growth_advance = 0;
 static void advance_floodplain_growth_tile(int x, int y, int grid_offset, int order) {
     if (map_terrain_is(grid_offset, TERRAIN_WATER) || map_terrain_is(grid_offset, TERRAIN_BUILDING)

--- a/src/window/empire.c
+++ b/src/window/empire.c
@@ -506,11 +506,11 @@ static void draw_panel_buttons(const empire_city *city) {
 
     // trade button
     if (city && !city->is_open) {
-        if (GAME_ENV == ENGINE_ENV_C3 && city->type == EMPIRE_CITY_TRADE
-            || GAME_ENV == ENGINE_ENV_PHARAOH &&
+        if ((GAME_ENV == ENGINE_ENV_C3 && city->type == EMPIRE_CITY_TRADE)
+            || (GAME_ENV == ENGINE_ENV_PHARAOH &&
            (city->type == EMPIRE_CITY_PH_PHARAOH_TRADE
             || city->type == EMPIRE_CITY_PH_EGYPT_TRADE
-            || city->type == EMPIRE_CITY_PH_FOREIGN_TRADE))
+            || city->type == EMPIRE_CITY_PH_FOREIGN_TRADE)))
             button_border_draw((data.x_min + data.x_max - 500) / 2 + 30 + TRADE_BUTTON_OFFSET_X,
                                data.y_max - 49 + TRADE_BUTTON_OFFSET_Y,
                                generic_button_open_trade[0].width, generic_button_open_trade[0].height,
@@ -635,11 +635,11 @@ static void handle_input(const mouse *m, const hotkeys *h) {
             data.selected_city = empire_city_get_for_object(selected_object - 1);
             const empire_city *city = empire_city_get(data.selected_city);
 
-            if (GAME_ENV == ENGINE_ENV_C3 && city->type == EMPIRE_CITY_TRADE
-                || GAME_ENV == ENGINE_ENV_PHARAOH &&
+            if ((GAME_ENV == ENGINE_ENV_C3 && city->type == EMPIRE_CITY_TRADE)
+                || (GAME_ENV == ENGINE_ENV_PHARAOH &&
                     (city->type == EMPIRE_CITY_PH_PHARAOH_TRADE
                     || city->type == EMPIRE_CITY_PH_EGYPT_TRADE
-                    || city->type == EMPIRE_CITY_PH_FOREIGN_TRADE)) {
+                    || city->type == EMPIRE_CITY_PH_FOREIGN_TRADE))) {
                 if (city->is_open) {
                     int x_offset = (data.x_min + data.x_max - 500) / 2;
                     int y_offset = data.y_max - 113;


### PR DESCRIPTION
To get warmed up with the code in the project I had a look at and fixed the warnings clang threw at me.
There's a variety, I recommend you look at the individual commits.

Most of the fixes are straight forward, however some cases of `&& and ||` precedence were not quite clear to me, you should really have a very close look at each of them. I'll mark those I am not sure about.