### PR TITLE
Load music formats

### DIFF
--- a/src/platform/sound_device.c
+++ b/src/platform/sound_device.c
@@ -152,6 +152,25 @@ void sound_device_close(void) {
     }
 }
 
+void sound_device_load_formats(void) {
+    if (!data.initialized) {
+        return;
+    }
+
+    const int flags = MIX_INIT_MP3;
+    const int initialized_flags = Mix_Init(flags);
+    if (flags != (flags & initialized_flags)) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Could not initialize SDL_mixer (%i, %i): %s", flags, initialized_flags, Mix_GetError());
+    }
+    else {
+        SDL_Log("SDL_mixer initialized: %i", initialized_flags);
+    }
+}
+
+void sound_device_unload_formats(void) {
+    Mix_Quit();
+}
+
 int sound_device_is_channel_playing(int channel) {
     return data.channels[channel].chunk && Mix_Playing(channel);
 }

--- a/src/sound/device.h
+++ b/src/sound/device.h
@@ -6,6 +6,9 @@
 void sound_device_open(void);
 void sound_device_close(void);
 
+void sound_device_load_formats(void);
+void sound_device_unload_formats(void);
+
 void sound_device_init_channels(int num_channels, char filenames[][CHANNEL_FILENAME_MAX]);
 int sound_device_is_channel_playing(int channel);
 

--- a/src/sound/system.c
+++ b/src/sound/system.c
@@ -349,6 +349,7 @@ void sound_system_init(void) {
 
     sound_device_open();
     sound_device_init_channels(SOUND_CHANNEL_MAX, channel_filenames[GAME_ENV]);
+    sound_device_load_formats();
 
     sound_city_set_volume(setting_sound(SOUND_CITY)->volume);
     sound_effect_set_volume(setting_sound(SOUND_EFFECTS)->volume);
@@ -357,4 +358,10 @@ void sound_system_init(void) {
 }
 void sound_system_shutdown(void) {
     sound_device_close();
+
+    // It is counter-intuitive that we must do this after sound_device_close, however it unloads shared libraries
+    // which might be required both for sound_device_close and by other threads fetching new audio chunks until
+    // sound_device_close is called. It is also surprising that we can (and must) call Mix_Quit after Mix_CloseAudio,
+    // even though Mix_CloseAudio's docs say that afterwards "the SDL_mixer functions should not be used".
+    sound_device_unload_formats();
 }


### PR DESCRIPTION
After running the game for the first time (and playing for a little bit 😃) I noticed some errors in the log concerning loading MP3 music.
I had a look at how this could potentially be fixed and found out that SDL2_mixer can load extensions for different formats. So I added the code to initialize all available music formats.
(I didn't really want to hardcode which formats to load inside the engine, but we could also forward the formats requested somehow - to at least log an error if an important format is missing. But I don't know well enough how the engine is structure and how such game specific settings should best be forwarded.)

Review the 2 commits individually. In the 2nd one I went a bit overboard with logging which formats are loaded ^^

Note that my default SDL2_mixer installation on macOS via homebrew didn't have any MP3 support built-in. But after building SDL2_mixer from source with MP3 support enabled, it worked like a charm. I have no idea what the version of SDL2_mixer supports that we suggest people install on other platforms. Perhaps we should update the build instructions mentioning this?